### PR TITLE
Remove default super user password / Update Salt generation / Allow to use different hash function if desired

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,4 +24,9 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            junit '**/TEST-*.xml'
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,30 @@ pipeline {
             steps {
                 wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
                     sh '''
+                        export EMFSTORE_TEST_SERVER_ROOT_DIR=$PWD
+                        echo EMFSTORE_TEST_SERVER_ROOT_DIR = $EMFSTORE_TEST_SERVER_ROOT_DIR
+                        mkdir -p $EMFSTORE_TEST_SERVER_ROOT_DIR/profiles/default_test/./conf/
+                        cat <<EOT >> $EMFSTORE_TEST_SERVER_ROOT_DIR/profiles/default_test/./conf/es.properties
+emfstore.startup.post.loadlistener=true
+emfstore.keystore.certificate.type=SunX509
+emfstore.accesscontrol.authentication.superuser.password.hash=f262c3daf9b9c8fd380bdf34a415ee01c38e423d956d4f9c732273cf51264783787415c3b6d8701f3416735a31b06b8330e0be0d17ae5361ef83de320f17ba84
+emfstore.accesscontrol.authentication.superuser.password.salt=8a0InZ2yZMss65zHJrdhOXU6CqF8EeFncdv7V29ZO4qD565i5deWWXIi7aRkYwbY2BWamdOYQGqoZeZiJHZ0BH1mteMIhu3eIG5D2twfVQtjetvf8kiLOMwnYDsk4HPq
+emfstore.keystore.alias=emfstoreServer
+emfstore.accesscontrol.authentication.policy=spfv
+emfstore.acceptedversions=any
+emfstore.validation.level=7
+emfstore.validation.exclude=
+emfstore.connection.rmi.encryption=true
+emfstore.startup.loadlistener=false
+emfstore.keystore.cipher.algorithm=RSA
+emfstore.keystore.password=123456
+emfstore.connection.xmlrpc.port=8080
+emfstore.validation=true
+emfstore.persistence.version.projectstate.everyxversions=50
+emfstore.accesscontrol.authentication.superuser=super
+emfstore.accesscontrol.session.timeout=1800000
+EOT
+                        cat $EMFSTORE_TEST_SERVER_ROOT_DIR/profiles/default_test/./conf/es.properties
                         metacity --replace --sm-disable &
                         cd releng/emfstore-parent
                         mvn clean verify -Dcheckstyle.skip

--- a/bundles/org.eclipse.emf.emfstore.client.ui/EMFStore Client 1 with ExampleModel.launch
+++ b/bundles/org.eclipse.emf.emfstore.client.ui/EMFStore Client 1 with ExampleModel.launch
@@ -8,7 +8,7 @@
 </setAttribute>
 <booleanAttribute key="append.args" value="true"/>
 <booleanAttribute key="askclear" value="true"/>
-<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticAdd" value="false"/>
 <booleanAttribute key="automaticValidate" value="false"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
@@ -17,10 +17,10 @@
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/EMFStore Client 1 with ExampleModel"/>
 <booleanAttribute key="default" value="false"/>
-<stringAttribute key="deselected_workspace_plugins" value="org.eclipse.emf.emfstore.client.test.alltests,org.eclipse.emf.emfstore.client.test.ui,org.eclipse.emf.emfstore.client.transaction"/>
+<setAttribute key="deselected_workspace_bundles"/>
 <stringAttribute key="featureDefaultLocation" value="workspace"/>
 <stringAttribute key="featurePluginResolution" value="workspace"/>
-<booleanAttribute key="includeOptional" value="true"/>
+<booleanAttribute key="includeOptional" value="false"/>
 <stringAttribute key="location" value="${workspace_loc}/../runtime-New_configuration"/>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
@@ -42,8 +42,167 @@
 <setEntry value="org.eclipse.emf.emfstore.internal.common.feature:default"/>
 <setEntry value="org.eclipse.emf.emfstore.internal.server.feature:default"/>
 </setAttribute>
-<stringAttribute key="selected_target_plugins" value="com.google.guava@default:default,com.ibm.icu@default:default,javax.annotation*1.0.0.v20101115-0725@default:default,javax.annotation*1.2.0.v201401042248@default:default,javax.inject@default:default,javax.servlet@default:default,javax.xml@default:default,org.apache.batik.css@default:default,org.apache.batik.util.gui@default:default,org.apache.batik.util@default:default,org.apache.commons.codec*1.3.0.v201101211617@default:default,org.apache.commons.codec*1.6.0.v201305230611@default:default,org.apache.commons.logging*1.1.1.v201101211721@default:default,org.eclipse.ant.core@default:default,org.eclipse.compare.core@default:default,org.eclipse.compare@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.beans@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filebuffers@default:default,org.eclipse.core.filesystem.linux.ppc64@default:false,org.eclipse.core.filesystem.linux.ppc@default:false,org.eclipse.core.filesystem.linux.x86@default:false,org.eclipse.core.filesystem.linux.x86_64@default:false,org.eclipse.core.filesystem.win32.x86_64@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.net.linux.x86@default:false,org.eclipse.core.net.linux.x86_64@default:false,org.eclipse.core.net.win32.x86_64@default:false,org.eclipse.core.net@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:false,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.e4.core.commands@default:default,org.eclipse.e4.core.contexts@default:default,org.eclipse.e4.core.di.extensions@default:default,org.eclipse.e4.core.di@default:default,org.eclipse.e4.core.services@default:default,org.eclipse.e4.ui.bindings@default:default,org.eclipse.e4.ui.css.core@default:default,org.eclipse.e4.ui.css.swt.theme@default:default,org.eclipse.e4.ui.css.swt@default:default,org.eclipse.e4.ui.di@default:default,org.eclipse.e4.ui.model.workbench@default:default,org.eclipse.e4.ui.services@default:default,org.eclipse.e4.ui.widgets@default:default,org.eclipse.e4.ui.workbench.addons.swt@default:default,org.eclipse.e4.ui.workbench.renderers.swt@default:default,org.eclipse.e4.ui.workbench.swt@default:default,org.eclipse.e4.ui.workbench3@default:default,org.eclipse.e4.ui.workbench@default:default,org.eclipse.emf.cdo.ecore.retrofit@default:false,org.eclipse.emf.common.ui@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.compare.edit@default:default,org.eclipse.emf.compare.ide.ui@default:default,org.eclipse.emf.compare.ide@default:default,org.eclipse.emf.compare.rcp.ui@default:default,org.eclipse.emf.compare.rcp@default:default,org.eclipse.emf.compare@default:default,org.eclipse.emf.databinding.edit@default:default,org.eclipse.emf.databinding@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.edit@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.emf.ecp.application.e3@default:default,org.eclipse.emf.ecp.common@default:default,org.eclipse.emf.ecp.core.emffilter@default:default,org.eclipse.emf.ecp.core@default:default,org.eclipse.emf.ecp.edit.ecore.swt@default:default,org.eclipse.emf.ecp.edit.swt@default:default,org.eclipse.emf.ecp.edit@default:default,org.eclipse.emf.ecp.editor.e3@default:default,org.eclipse.emf.ecp.emfstore.core@default:default,org.eclipse.emf.ecp.emfstore.ui.e3@default:default,org.eclipse.emf.ecp.emfstore.ui.search@default:default,org.eclipse.emf.ecp.emfstore.ui@default:default,org.eclipse.emf.ecp.explorereditorbridge@default:default,org.eclipse.emf.ecp.ui.e3@default:default,org.eclipse.emf.ecp.ui.e4@default:default,org.eclipse.emf.ecp.ui.rcp@default:false,org.eclipse.emf.ecp.ui.view.swt@default:default,org.eclipse.emf.ecp.ui.view@default:default,org.eclipse.emf.ecp.ui@default:default,org.eclipse.emf.ecp.view.categorization.model@default:default,org.eclipse.emf.ecp.view.categorization.swt@default:default,org.eclipse.emf.ecp.view.context@default:default,org.eclipse.emf.ecp.view.core.swt@default:default,org.eclipse.emf.ecp.view.custom.model@default:default,org.eclipse.emf.ecp.view.custom.ui.swt@default:default,org.eclipse.emf.ecp.view.custom.ui@default:default,org.eclipse.emf.ecp.view.group.model@default:default,org.eclipse.emf.ecp.view.group.ui.swt@default:default,org.eclipse.emf.ecp.view.groupedgrid.model@default:default,org.eclipse.emf.ecp.view.groupedgrid.ui.swt@default:default,org.eclipse.emf.ecp.view.horizontal.model@default:default,org.eclipse.emf.ecp.view.horizontal.ui.swt@default:default,org.eclipse.emf.ecp.view.label.model@default:default,org.eclipse.emf.ecp.view.label.ui.swt@default:default,org.eclipse.emf.ecp.view.model.provider.generator@default:default,org.eclipse.emf.ecp.view.model@default:default,org.eclipse.emf.ecp.view.separator.model@default:default,org.eclipse.emf.ecp.view.separator.ui.swt@default:default,org.eclipse.emf.ecp.view.table.model@default:default,org.eclipse.emf.ecp.view.table.ui.swt@default:default,org.eclipse.emf.ecp.view.template.controls.swt@default:default,org.eclipse.emf.ecp.view.template.model@default:default,org.eclipse.emf.ecp.view.treemasterdetail.model@default:default,org.eclipse.emf.ecp.view.treemasterdetail.ui.swt@default:default,org.eclipse.emf.ecp.view.validation@default:default,org.eclipse.emf.ecp.view.vertical.model@default:default,org.eclipse.emf.ecp.view.vertical.ui.swt@default:default,org.eclipse.emf.edit.ui@default:default,org.eclipse.emf.edit@default:default,org.eclipse.emf.transaction@default:default,org.eclipse.emf.validation@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.ds@1:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.launcher.gtk.linux.ppc64@default:false,org.eclipse.equinox.launcher.gtk.linux.ppc@default:false,org.eclipse.equinox.launcher.gtk.linux.s390@default:false,org.eclipse.equinox.launcher.gtk.linux.s390x@default:false,org.eclipse.equinox.launcher.gtk.linux.x86@default:false,org.eclipse.equinox.launcher.gtk.linux.x86_64@default:false,org.eclipse.equinox.launcher@default:default,org.eclipse.equinox.p2.core@default:default,org.eclipse.equinox.p2.engine@default:default,org.eclipse.equinox.p2.metadata.repository@default:default,org.eclipse.equinox.p2.metadata@default:default,org.eclipse.equinox.p2.repository@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.security.win32.x86_64@default:false,org.eclipse.equinox.security@default:default,org.eclipse.equinox.servletbridge.extensionbundle@default:false,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.util@default:default,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.help@default:default,org.eclipse.jface.databinding@default:default,org.eclipse.jface.text@default:default,org.eclipse.jface@default:default,org.eclipse.net4j.util@default:default,org.eclipse.osgi*3.8.2.v20130124-134944@-1:true,org.eclipse.osgi.services@default:default,org.eclipse.swt.gtk.linux.ppc64@default:false,org.eclipse.swt.gtk.linux.ppc@default:false,org.eclipse.swt.gtk.linux.s390@default:false,org.eclipse.swt.gtk.linux.s390x@default:false,org.eclipse.swt.gtk.linux.x86@default:false,org.eclipse.swt.gtk.linux.x86_64@default:false,org.eclipse.swt.win32.win32.x86_64@default:false,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.team.ui@default:default,org.eclipse.text@default:default,org.eclipse.ui.editors@default:default,org.eclipse.ui.forms@default:default,org.eclipse.ui.ide.application@default:default,org.eclipse.ui.ide@default:default,org.eclipse.ui.navigator@default:default,org.eclipse.ui.views@default:default,org.eclipse.ui.win32@default:false,org.eclipse.ui.workbench.texteditor@default:default,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:default,org.hamcrest.core@default:default,org.hamcrest.library@default:default,org.junit@default:default,org.w3c.css.sac@default:default,org.w3c.dom.smil@default:default,org.w3c.dom.svg@default:default"/>
-<stringAttribute key="selected_workspace_plugins" value="org.eclipse.emf.emfstore.branding@default:default,org.eclipse.emf.emfstore.client.api.test@default:false,org.eclipse.emf.emfstore.client.conflictdetection.test@default:false,org.eclipse.emf.emfstore.client.example.test@default:default,org.eclipse.emf.emfstore.client.model.edit@default:default,org.eclipse.emf.emfstore.client.recording.test@default:false,org.eclipse.emf.emfstore.client.test@default:default,org.eclipse.emf.emfstore.client.ui.historybrowsercomparator@default:default,org.eclipse.emf.emfstore.client.ui.rap@default:false,org.eclipse.emf.emfstore.client.ui.rcp@default:false,org.eclipse.emf.emfstore.client.ui@default:default,org.eclipse.emf.emfstore.client@default:default,org.eclipse.emf.emfstore.common.model.edit@default:default,org.eclipse.emf.emfstore.common.model@default:default,org.eclipse.emf.emfstore.common@default:default,org.eclipse.emf.emfstore.ecore@default:default,org.eclipse.emf.emfstore.example.helloworld@default:default,org.eclipse.emf.emfstore.example.installer@default:default,org.eclipse.emf.emfstore.example.merging@default:default,org.eclipse.emf.emfstore.example.sessionprovider@default:default,org.eclipse.emf.emfstore.examplemodel.edit@default:default,org.eclipse.emf.emfstore.examplemodel@default:default,org.eclipse.emf.emfstore.migration@default:default,org.eclipse.emf.emfstore.server.model.edit@default:default,org.eclipse.emf.emfstore.server.model@default:default,org.eclipse.emf.emfstore.server.test@default:false,org.eclipse.emf.emfstore.server@default:default,org.eclipse.emf.emfstore.test.common@default:default,org.eclipse.emf.emfstore.test.model.edit@default:default,org.eclipse.emf.emfstore.test.model@default:default"/>
+<setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:false"/>
+<setEntry value="com.google.guava@default:default"/>
+<setEntry value="com.ibm.icu@default:default"/>
+<setEntry value="javax.annotation@default:default"/>
+<setEntry value="javax.inject@default:default"/>
+<setEntry value="javax.xml@default:default"/>
+<setEntry value="lpg.runtime.java@default:default"/>
+<setEntry value="org.apache.batik.css@default:default"/>
+<setEntry value="org.apache.batik.util.gui@default:default"/>
+<setEntry value="org.apache.batik.util@default:default"/>
+<setEntry value="org.apache.commons.codec*1.6.0.v201305230611@default:default"/>
+<setEntry value="org.apache.felix.gogo.command@default:default"/>
+<setEntry value="org.apache.felix.gogo.runtime@default:default"/>
+<setEntry value="org.eclipse.ant.core@default:default"/>
+<setEntry value="org.eclipse.compare.core@default:default"/>
+<setEntry value="org.eclipse.compare@default:default"/>
+<setEntry value="org.eclipse.core.commands@default:default"/>
+<setEntry value="org.eclipse.core.contenttype@default:default"/>
+<setEntry value="org.eclipse.core.databinding.beans@default:default"/>
+<setEntry value="org.eclipse.core.databinding.observable@default:default"/>
+<setEntry value="org.eclipse.core.databinding.property@default:default"/>
+<setEntry value="org.eclipse.core.databinding@default:default"/>
+<setEntry value="org.eclipse.core.expressions@default:default"/>
+<setEntry value="org.eclipse.core.filebuffers@default:default"/>
+<setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.filesystem@default:default"/>
+<setEntry value="org.eclipse.core.jobs@default:default"/>
+<setEntry value="org.eclipse.core.net.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.net@default:default"/>
+<setEntry value="org.eclipse.core.resources@default:default"/>
+<setEntry value="org.eclipse.core.runtime.compatibility.registry@default:false"/>
+<setEntry value="org.eclipse.core.runtime@default:true"/>
+<setEntry value="org.eclipse.core.variables@default:default"/>
+<setEntry value="org.eclipse.e4.core.commands@default:default"/>
+<setEntry value="org.eclipse.e4.core.contexts@default:default"/>
+<setEntry value="org.eclipse.e4.core.di.extensions@default:default"/>
+<setEntry value="org.eclipse.e4.core.di@default:default"/>
+<setEntry value="org.eclipse.e4.core.services@default:default"/>
+<setEntry value="org.eclipse.e4.ui.bindings@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.core@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.swt.theme@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.di@default:default"/>
+<setEntry value="org.eclipse.e4.ui.model.workbench@default:default"/>
+<setEntry value="org.eclipse.e4.ui.services@default:default"/>
+<setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench@default:default"/>
+<setEntry value="org.eclipse.emf.cdo.ecore.retrofit@default:false"/>
+<setEntry value="org.eclipse.emf.common.ui@default:default"/>
+<setEntry value="org.eclipse.emf.common@default:default"/>
+<setEntry value="org.eclipse.emf.compare.edit*4.0.0.201501201328@default:default"/>
+<setEntry value="org.eclipse.emf.compare.ide.ui@default:default"/>
+<setEntry value="org.eclipse.emf.compare.ide@default:default"/>
+<setEntry value="org.eclipse.emf.compare.rcp.ui@default:default"/>
+<setEntry value="org.eclipse.emf.compare.rcp@default:default"/>
+<setEntry value="org.eclipse.emf.compare@default:default"/>
+<setEntry value="org.eclipse.emf.databinding.edit@default:default"/>
+<setEntry value="org.eclipse.emf.databinding@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.change@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.edit@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
+<setEntry value="org.eclipse.emf.ecore@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.application.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.common@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.core@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.edit.swt@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.edit@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.editor.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.core@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.ui.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.ui@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.rcp@default:false"/>
+<setEntry value="org.eclipse.emf.ecp.ui.view.swt@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.view@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.context@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.model@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.template.model@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.validation@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.common@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.declaration@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.history@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.migration@default:default"/>
+<setEntry value="org.eclipse.emf.edit.ui@default:default"/>
+<setEntry value="org.eclipse.emf.edit@default:default"/>
+<setEntry value="org.eclipse.emf.transaction@default:default"/>
+<setEntry value="org.eclipse.emf.validation@default:default"/>
+<setEntry value="org.eclipse.equinox.app@default:default"/>
+<setEntry value="org.eclipse.equinox.common@2:true"/>
+<setEntry value="org.eclipse.equinox.ds@1:true"/>
+<setEntry value="org.eclipse.equinox.event@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.core@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.engine@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.metadata.repository@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.metadata@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.repository@default:default"/>
+<setEntry value="org.eclipse.equinox.preferences@default:default"/>
+<setEntry value="org.eclipse.equinox.registry@default:default"/>
+<setEntry value="org.eclipse.equinox.security@default:default"/>
+<setEntry value="org.eclipse.equinox.servletbridge.extensionbundle@default:false"/>
+<setEntry value="org.eclipse.equinox.transforms.hook@default:false"/>
+<setEntry value="org.eclipse.equinox.util@default:default"/>
+<setEntry value="org.eclipse.equinox.weaving.hook@default:false"/>
+<setEntry value="org.eclipse.help@default:default"/>
+<setEntry value="org.eclipse.jface.databinding@default:default"/>
+<setEntry value="org.eclipse.jface.text@default:default"/>
+<setEntry value="org.eclipse.jface@default:default"/>
+<setEntry value="org.eclipse.net4j.util@default:default"/>
+<setEntry value="org.eclipse.ocl.common@default:default"/>
+<setEntry value="org.eclipse.ocl.ecore@default:default"/>
+<setEntry value="org.eclipse.ocl@default:default"/>
+<setEntry value="org.eclipse.osgi*3.8.2.v20130124-134944@-1:true"/>
+<setEntry value="org.eclipse.osgi.services@default:default"/>
+<setEntry value="org.eclipse.swt.gtk.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.swt@default:default"/>
+<setEntry value="org.eclipse.team.core@default:default"/>
+<setEntry value="org.eclipse.team.ui@default:default"/>
+<setEntry value="org.eclipse.text@default:default"/>
+<setEntry value="org.eclipse.ui.editors@default:default"/>
+<setEntry value="org.eclipse.ui.forms@default:default"/>
+<setEntry value="org.eclipse.ui.ide.application@default:default"/>
+<setEntry value="org.eclipse.ui.ide@default:default"/>
+<setEntry value="org.eclipse.ui.navigator@default:default"/>
+<setEntry value="org.eclipse.ui.views@default:default"/>
+<setEntry value="org.eclipse.ui.workbench.texteditor@default:default"/>
+<setEntry value="org.eclipse.ui.workbench@default:default"/>
+<setEntry value="org.eclipse.ui@default:default"/>
+<setEntry value="org.hamcrest.core*1.3.0.v201303031735@default:default"/>
+<setEntry value="org.hamcrest.library@default:default"/>
+<setEntry value="org.junit*4.10.0.v4_10_0_v20120426-0900@default:default"/>
+<setEntry value="org.slf4j.api@default:default"/>
+<setEntry value="org.slf4j.jcl@default:default"/>
+<setEntry value="org.w3c.css.sac@default:default"/>
+<setEntry value="org.w3c.dom.smil@default:default"/>
+<setEntry value="org.w3c.dom.svg@default:default"/>
+</setAttribute>
+<setAttribute key="selected_workspace_bundles">
+<setEntry value="org.eclipse.emf.emfstore.branding@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client.ui.rcp@default:false"/>
+<setEntry value="org.eclipse.emf.emfstore.client.ui@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration.edapt@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server@default:default"/>
+</setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
 <booleanAttribute key="tracing" value="false"/>

--- a/bundles/org.eclipse.emf.emfstore.client.ui/EMFStore Client 2 with ExampleModel.launch
+++ b/bundles/org.eclipse.emf.emfstore.client.ui/EMFStore Client 2 with ExampleModel.launch
@@ -8,24 +8,24 @@
 </setAttribute>
 <booleanAttribute key="append.args" value="true"/>
 <booleanAttribute key="askclear" value="true"/>
-<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticAdd" value="false"/>
 <booleanAttribute key="automaticValidate" value="false"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/EMFStore Client 2 with ExampleModel"/>
 <booleanAttribute key="default" value="false"/>
-<stringAttribute key="deselected_workspace_plugins" value="org.eclipse.emf.emfstore.client.test,org.eclipse.emf.emfstore.client.test.alltests,org.eclipse.emf.emfstore.client.test.ui,org.eclipse.emf.emfstore.client.ui.historybrowsercomparator,org.eclipse.emf.emfstore.fuzzy,org.eclipse.emf.emfstore.fuzzy.emf,org.eclipse.emf.emfstore.fuzzy.emf.edit,org.eclipse.emf.emfstore.fuzzy.emf.editor,org.eclipse.emf.emfstore.fuzzy.emf.example,org.eclipse.emf.emfstore.fuzzy.emf.test"/>
+<setAttribute key="deselected_workspace_bundles"/>
 <stringAttribute key="featureDefaultLocation" value="workspace"/>
 <stringAttribute key="featurePluginResolution" value="workspace"/>
-<booleanAttribute key="includeOptional" value="true"/>
-<stringAttribute key="location" value="${workspace_loc}/../runtime-New_configuration"/>
+<booleanAttribute key="includeOptional" value="false"/>
+<stringAttribute key="location" value="${workspace_loc}/../runtime-New_configuration2"/>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
 </listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -profile=client2"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1024m"/>
@@ -42,8 +42,167 @@
 <setEntry value="org.eclipse.emf.emfstore.internal.common.feature:default"/>
 <setEntry value="org.eclipse.emf.emfstore.internal.server.feature:default"/>
 </setAttribute>
-<stringAttribute key="selected_target_plugins" value="com.ibm.icu@default:default,javax.annotation@default:default,javax.inject@default:default,javax.servlet@default:default,javax.xml@default:default,org.apache.batik.css@default:default,org.apache.batik.util.gui@default:default,org.apache.batik.util@default:default,org.apache.commons.codec@default:default,org.apache.commons.logging*1.1.1.v201101211721@default:default,org.eclipse.ant.core@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.win32.x86_64@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:false,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.e4.core.commands@default:default,org.eclipse.e4.core.contexts@default:default,org.eclipse.e4.core.di.extensions@default:default,org.eclipse.e4.core.di@default:default,org.eclipse.e4.core.services@default:default,org.eclipse.e4.ui.bindings@default:default,org.eclipse.e4.ui.css.core@default:default,org.eclipse.e4.ui.css.swt.theme@default:default,org.eclipse.e4.ui.css.swt@default:default,org.eclipse.e4.ui.di@default:default,org.eclipse.e4.ui.model.workbench@default:default,org.eclipse.e4.ui.services@default:default,org.eclipse.e4.ui.widgets@default:default,org.eclipse.e4.ui.workbench.renderers.swt@default:default,org.eclipse.e4.ui.workbench.swt@default:default,org.eclipse.e4.ui.workbench3@default:default,org.eclipse.e4.ui.workbench@default:default,org.eclipse.emf.cdo.ecore.retrofit@default:false,org.eclipse.emf.common.ui@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.databinding.edit@default:default,org.eclipse.emf.databinding@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.emf.ecp.application.e3@default:default,org.eclipse.emf.ecp.common@default:default,org.eclipse.emf.ecp.core.emffilter@default:default,org.eclipse.emf.ecp.core@default:default,org.eclipse.emf.ecp.edit.swt@default:default,org.eclipse.emf.ecp.edit@default:default,org.eclipse.emf.ecp.editor.e3@default:default,org.eclipse.emf.ecp.editor@default:default,org.eclipse.emf.ecp.emfstore.core@default:default,org.eclipse.emf.ecp.emfstore.ui.search@default:default,org.eclipse.emf.ecp.emfstore.ui@default:default,org.eclipse.emf.ecp.explorereditorbridge@default:default,org.eclipse.emf.ecp.ui.e3@default:default,org.eclipse.emf.ecp.ui@default:default,org.eclipse.emf.edit.ui@default:default,org.eclipse.emf.edit@default:default,org.eclipse.emf.transaction@default:default,org.eclipse.emf.validation@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.ds@1:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.p2.core@default:default,org.eclipse.equinox.p2.engine@default:default,org.eclipse.equinox.p2.metadata.repository@default:default,org.eclipse.equinox.p2.metadata@default:default,org.eclipse.equinox.p2.repository@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.security.win32.x86_64@default:false,org.eclipse.equinox.security@default:default,org.eclipse.equinox.servletbridge.extensionbundle@default:false,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.util@default:default,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.help@default:default,org.eclipse.jface.databinding@default:default,org.eclipse.jface.text@default:default,org.eclipse.jface@default:default,org.eclipse.net4j.util@default:default,org.eclipse.osgi.services@default:default,org.eclipse.osgi@-1:true,org.eclipse.swt.win32.win32.x86_64@default:false,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.text@default:default,org.eclipse.ui.forms@default:default,org.eclipse.ui.ide@default:default,org.eclipse.ui.views@default:default,org.eclipse.ui.win32@default:false,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:default,org.w3c.css.sac@default:default,org.w3c.dom.smil@default:default,org.w3c.dom.svg@default:default"/>
-<stringAttribute key="selected_workspace_plugins" value="org.eclipse.emf.emfstore.branding@default:default,org.eclipse.emf.emfstore.client.model.edit@default:default,org.eclipse.emf.emfstore.client.transaction@default:default,org.eclipse.emf.emfstore.client.ui@default:default,org.eclipse.emf.emfstore.client@default:default,org.eclipse.emf.emfstore.common.model.edit@default:default,org.eclipse.emf.emfstore.common.model@default:default,org.eclipse.emf.emfstore.common@default:default,org.eclipse.emf.emfstore.ecore@default:default,org.eclipse.emf.emfstore.example.helloworld@default:default,org.eclipse.emf.emfstore.example.installer@default:default,org.eclipse.emf.emfstore.example.merging@default:default,org.eclipse.emf.emfstore.example.sessionprovider@default:default,org.eclipse.emf.emfstore.examplemodel.edit@default:default,org.eclipse.emf.emfstore.examplemodel@default:default,org.eclipse.emf.emfstore.migration@default:default,org.eclipse.emf.emfstore.modelmutator@default:default,org.eclipse.emf.emfstore.server.model.edit@default:default,org.eclipse.emf.emfstore.server.model@default:default,org.eclipse.emf.emfstore.server@default:default"/>
+<setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:false"/>
+<setEntry value="com.google.guava@default:default"/>
+<setEntry value="com.ibm.icu@default:default"/>
+<setEntry value="javax.annotation@default:default"/>
+<setEntry value="javax.inject@default:default"/>
+<setEntry value="javax.xml@default:default"/>
+<setEntry value="lpg.runtime.java@default:default"/>
+<setEntry value="org.apache.batik.css@default:default"/>
+<setEntry value="org.apache.batik.util.gui@default:default"/>
+<setEntry value="org.apache.batik.util@default:default"/>
+<setEntry value="org.apache.commons.codec*1.6.0.v201305230611@default:default"/>
+<setEntry value="org.apache.felix.gogo.command@default:default"/>
+<setEntry value="org.apache.felix.gogo.runtime@default:default"/>
+<setEntry value="org.eclipse.ant.core@default:default"/>
+<setEntry value="org.eclipse.compare.core@default:default"/>
+<setEntry value="org.eclipse.compare@default:default"/>
+<setEntry value="org.eclipse.core.commands@default:default"/>
+<setEntry value="org.eclipse.core.contenttype@default:default"/>
+<setEntry value="org.eclipse.core.databinding.beans@default:default"/>
+<setEntry value="org.eclipse.core.databinding.observable@default:default"/>
+<setEntry value="org.eclipse.core.databinding.property@default:default"/>
+<setEntry value="org.eclipse.core.databinding@default:default"/>
+<setEntry value="org.eclipse.core.expressions@default:default"/>
+<setEntry value="org.eclipse.core.filebuffers@default:default"/>
+<setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.filesystem@default:default"/>
+<setEntry value="org.eclipse.core.jobs@default:default"/>
+<setEntry value="org.eclipse.core.net.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.net@default:default"/>
+<setEntry value="org.eclipse.core.resources@default:default"/>
+<setEntry value="org.eclipse.core.runtime.compatibility.registry@default:false"/>
+<setEntry value="org.eclipse.core.runtime@default:true"/>
+<setEntry value="org.eclipse.core.variables@default:default"/>
+<setEntry value="org.eclipse.e4.core.commands@default:default"/>
+<setEntry value="org.eclipse.e4.core.contexts@default:default"/>
+<setEntry value="org.eclipse.e4.core.di.extensions@default:default"/>
+<setEntry value="org.eclipse.e4.core.di@default:default"/>
+<setEntry value="org.eclipse.e4.core.services@default:default"/>
+<setEntry value="org.eclipse.e4.ui.bindings@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.core@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.swt.theme@default:default"/>
+<setEntry value="org.eclipse.e4.ui.css.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.di@default:default"/>
+<setEntry value="org.eclipse.e4.ui.model.workbench@default:default"/>
+<setEntry value="org.eclipse.e4.ui.services@default:default"/>
+<setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
+<setEntry value="org.eclipse.e4.ui.workbench@default:default"/>
+<setEntry value="org.eclipse.emf.cdo.ecore.retrofit@default:false"/>
+<setEntry value="org.eclipse.emf.common.ui@default:default"/>
+<setEntry value="org.eclipse.emf.common@default:default"/>
+<setEntry value="org.eclipse.emf.compare.edit*4.0.0.201501201328@default:default"/>
+<setEntry value="org.eclipse.emf.compare.ide.ui@default:default"/>
+<setEntry value="org.eclipse.emf.compare.ide@default:default"/>
+<setEntry value="org.eclipse.emf.compare.rcp.ui@default:default"/>
+<setEntry value="org.eclipse.emf.compare.rcp@default:default"/>
+<setEntry value="org.eclipse.emf.compare@default:default"/>
+<setEntry value="org.eclipse.emf.databinding.edit@default:default"/>
+<setEntry value="org.eclipse.emf.databinding@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.change@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.edit@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
+<setEntry value="org.eclipse.emf.ecore@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.application.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.common@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.core@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.edit.swt@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.edit@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.editor.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.core@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.ui.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.emfstore.ui@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.e3@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.rcp@default:false"/>
+<setEntry value="org.eclipse.emf.ecp.ui.view.swt@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui.view@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.ui@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.context@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.model@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.template.model@default:default"/>
+<setEntry value="org.eclipse.emf.ecp.view.validation@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.common@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.declaration@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.history@default:default"/>
+<setEntry value="org.eclipse.emf.edapt.migration@default:default"/>
+<setEntry value="org.eclipse.emf.edit.ui@default:default"/>
+<setEntry value="org.eclipse.emf.edit@default:default"/>
+<setEntry value="org.eclipse.emf.transaction@default:default"/>
+<setEntry value="org.eclipse.emf.validation@default:default"/>
+<setEntry value="org.eclipse.equinox.app@default:default"/>
+<setEntry value="org.eclipse.equinox.common@2:true"/>
+<setEntry value="org.eclipse.equinox.ds@1:true"/>
+<setEntry value="org.eclipse.equinox.event@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.core@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.engine@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.metadata.repository@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.metadata@default:default"/>
+<setEntry value="org.eclipse.equinox.p2.repository@default:default"/>
+<setEntry value="org.eclipse.equinox.preferences@default:default"/>
+<setEntry value="org.eclipse.equinox.registry@default:default"/>
+<setEntry value="org.eclipse.equinox.security@default:default"/>
+<setEntry value="org.eclipse.equinox.servletbridge.extensionbundle@default:false"/>
+<setEntry value="org.eclipse.equinox.transforms.hook@default:false"/>
+<setEntry value="org.eclipse.equinox.util@default:default"/>
+<setEntry value="org.eclipse.equinox.weaving.hook@default:false"/>
+<setEntry value="org.eclipse.help@default:default"/>
+<setEntry value="org.eclipse.jface.databinding@default:default"/>
+<setEntry value="org.eclipse.jface.text@default:default"/>
+<setEntry value="org.eclipse.jface@default:default"/>
+<setEntry value="org.eclipse.net4j.util@default:default"/>
+<setEntry value="org.eclipse.ocl.common@default:default"/>
+<setEntry value="org.eclipse.ocl.ecore@default:default"/>
+<setEntry value="org.eclipse.ocl@default:default"/>
+<setEntry value="org.eclipse.osgi*3.8.2.v20130124-134944@-1:true"/>
+<setEntry value="org.eclipse.osgi.services@default:default"/>
+<setEntry value="org.eclipse.swt.gtk.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.swt@default:default"/>
+<setEntry value="org.eclipse.team.core@default:default"/>
+<setEntry value="org.eclipse.team.ui@default:default"/>
+<setEntry value="org.eclipse.text@default:default"/>
+<setEntry value="org.eclipse.ui.editors@default:default"/>
+<setEntry value="org.eclipse.ui.forms@default:default"/>
+<setEntry value="org.eclipse.ui.ide.application@default:default"/>
+<setEntry value="org.eclipse.ui.ide@default:default"/>
+<setEntry value="org.eclipse.ui.navigator@default:default"/>
+<setEntry value="org.eclipse.ui.views@default:default"/>
+<setEntry value="org.eclipse.ui.workbench.texteditor@default:default"/>
+<setEntry value="org.eclipse.ui.workbench@default:default"/>
+<setEntry value="org.eclipse.ui@default:default"/>
+<setEntry value="org.hamcrest.core*1.3.0.v201303031735@default:default"/>
+<setEntry value="org.hamcrest.library@default:default"/>
+<setEntry value="org.junit*4.10.0.v4_10_0_v20120426-0900@default:default"/>
+<setEntry value="org.slf4j.api@default:default"/>
+<setEntry value="org.slf4j.jcl@default:default"/>
+<setEntry value="org.w3c.css.sac@default:default"/>
+<setEntry value="org.w3c.dom.smil@default:default"/>
+<setEntry value="org.w3c.dom.svg@default:default"/>
+</setAttribute>
+<setAttribute key="selected_workspace_bundles">
+<setEntry value="org.eclipse.emf.emfstore.branding@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client.ui.rcp@default:false"/>
+<setEntry value="org.eclipse.emf.emfstore.client.ui@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.client@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration.edapt@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server@default:default"/>
+</setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
 <booleanAttribute key="tracing" value="false"/>

--- a/bundles/org.eclipse.emf.emfstore.server/EMFStore Server with ExampleModel.launch
+++ b/bundles/org.eclipse.emf.emfstore.server/EMFStore Server with ExampleModel.launch
@@ -15,9 +15,10 @@
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/EMFStore Server with ExampleModel"/>
 <booleanAttribute key="default" value="false"/>
+<setAttribute key="deselected_workspace_bundles"/>
 <stringAttribute key="featureDefaultLocation" value="workspace"/>
 <stringAttribute key="featurePluginResolution" value="workspace"/>
-<booleanAttribute key="includeOptional" value="true"/>
+<booleanAttribute key="includeOptional" value="false"/>
 <stringAttribute key="location" value="${workspace_loc}/../runtime-org.eclipse.emf.emfstore.server.server"/>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
@@ -30,8 +31,51 @@
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.emf.emfstore.server.server"/>
 <setAttribute key="selected_features"/>
-<stringAttribute key="selected_target_plugins" value="javax.servlet*3.0.0.v201112011016@default:default,javax.servlet*3.1.0.v201410161800@default:default,javax.xml@default:default,org.apache.commons.codec@default:default,org.apache.commons.logging@default:default,org.eclipse.ant.core@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.linux.x86_64@default:default,org.eclipse.core.filesystem.win32.x86_64@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.emf.cdo.ecore.retrofit@default:false,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.osgi*3.11.1.v20160708-1632@-1:true,org.eclipse.osgi.services*3.5.100.v20160504-1419@default:default"/>
-<stringAttribute key="selected_workspace_plugins" value="org.eclipse.emf.emfstore.common.model@default:default,org.eclipse.emf.emfstore.common@default:default,org.eclipse.emf.emfstore.examplemodel@default:default,org.eclipse.emf.emfstore.migration@default:default,org.eclipse.emf.emfstore.server.model@default:default,org.eclipse.emf.emfstore.server@default:default"/>
+<setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:false"/>
+<setEntry value="javax.xml@default:default"/>
+<setEntry value="org.apache.commons.codec*1.6.0.v201305230611@default:default"/>
+<setEntry value="org.apache.felix.gogo.command@default:default"/>
+<setEntry value="org.apache.felix.gogo.runtime@default:default"/>
+<setEntry value="org.eclipse.ant.core@default:default"/>
+<setEntry value="org.eclipse.core.contenttype@default:default"/>
+<setEntry value="org.eclipse.core.expressions@default:default"/>
+<setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.filesystem@default:default"/>
+<setEntry value="org.eclipse.core.jobs@default:default"/>
+<setEntry value="org.eclipse.core.resources@default:default"/>
+<setEntry value="org.eclipse.core.runtime.compatibility.registry@default:false"/>
+<setEntry value="org.eclipse.core.runtime@default:true"/>
+<setEntry value="org.eclipse.core.variables@default:default"/>
+<setEntry value="org.eclipse.emf.cdo.ecore.retrofit@default:false"/>
+<setEntry value="org.eclipse.emf.common@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
+<setEntry value="org.eclipse.emf.ecore@default:default"/>
+<setEntry value="org.eclipse.equinox.app@default:default"/>
+<setEntry value="org.eclipse.equinox.common@2:true"/>
+<setEntry value="org.eclipse.equinox.ds@1:true"/>
+<setEntry value="org.eclipse.equinox.preferences@default:default"/>
+<setEntry value="org.eclipse.equinox.registry@default:default"/>
+<setEntry value="org.eclipse.equinox.servletbridge.extensionbundle@default:false"/>
+<setEntry value="org.eclipse.equinox.transforms.hook@default:false"/>
+<setEntry value="org.eclipse.equinox.util@default:default"/>
+<setEntry value="org.eclipse.equinox.weaving.hook@default:false"/>
+<setEntry value="org.eclipse.osgi*3.8.2.v20130124-134944@-1:true"/>
+<setEntry value="org.eclipse.osgi.services@default:default"/>
+<setEntry value="org.eclipse.team.core@default:default"/>
+<setEntry value="org.slf4j.api@default:default"/>
+<setEntry value="org.slf4j.jcl@default:default"/>
+</setAttribute>
+<setAttribute key="selected_workspace_bundles">
+<setEntry value="org.eclipse.emf.emfstore.common.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server@default:default"/>
+</setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <booleanAttribute key="tracing" value="false"/>
 <booleanAttribute key="useCustomFeatures" value="false"/>

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
@@ -204,11 +204,6 @@ public final class ServerConfiguration {
 	public static final String SUPER_USER_PASSWORD_SALT = "emfstore.accesscontrol.authentication.superuser.password.salt"; //$NON-NLS-1$
 
 	/**
-	 * Default super user password.
-	 */
-	public static final String SUPER_USER_PASSWORD_DEFAULT = "super"; //$NON-NLS-1$
-
-	/**
 	 * Property for authentication policy used by server. E.g. ldap or property
 	 * file.
 	 */

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/AccessControl.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/AccessControl.java
@@ -11,6 +11,7 @@
  ******************************************************************************/
 package org.eclipse.emf.emfstore.internal.server.accesscontrol;
 
+import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.util.List;
 
@@ -118,7 +119,11 @@ public class AccessControl {
 			final List<ESPasswordHashGenerator> services = new ESExtensionPoint(ACCESSCONTROL_EXTENSION_ID, false)
 				.getClasses(PASSWORD_HASH_GENERATOR_CLASS, ESPasswordHashGenerator.class);
 			if (services.isEmpty()) {
-				passwordHashGenerator = new DefaultESPasswordHashGenerator();
+				try {
+					passwordHashGenerator = new DefaultESPasswordHashGenerator();
+				} catch (final NoSuchAlgorithmException ex) {
+					throw new IllegalStateException(ex);
+				}
 			} else if (services.size() == 1) {
 				passwordHashGenerator = services.get(0);
 			} else {
@@ -130,7 +135,11 @@ public class AccessControl {
 		} catch (final ESExtensionPointException e) {
 			final String message = Messages.AccessControl_CustomAuthorizationInitFailed;
 			ModelUtil.logException(message, e);
-			passwordHashGenerator = new DefaultESPasswordHashGenerator();
+			try {
+				passwordHashGenerator = new DefaultESPasswordHashGenerator();
+			} catch (final NoSuchAlgorithmException ex) {
+				throw new IllegalStateException(ex);
+			}
 		}
 		AccessControl.passwordHashGenerator = passwordHashGenerator;
 		return passwordHashGenerator;

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/DefaultESPasswordHashGenerator.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/DefaultESPasswordHashGenerator.java
@@ -50,7 +50,7 @@ public class DefaultESPasswordHashGenerator implements ESPasswordHashGenerator {
 
 	private static final String PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1"; //$NON-NLS-1$
 
-	private static final int PBKDF2_ITERATION_COUT = 65536;
+	private static final int PBKDF2_ITERATION_COUNT = 65536;
 
 	private static final char[] ALPHANUMERIC_CHARS = ALPHANUMERIC.toCharArray();
 
@@ -114,7 +114,7 @@ public class DefaultESPasswordHashGenerator implements ESPasswordHashGenerator {
 	protected final String pBKDF2(String password, String salt) {
 		try {
 			final KeySpec spec = new PBEKeySpec(password.toCharArray(), salt.getBytes(), //
-				PBKDF2_ITERATION_COUT, KEY_LENGTH);
+				PBKDF2_ITERATION_COUNT, KEY_LENGTH);
 			final byte[] encoded = secretKeyFactory.generateSecret(spec).getEncoded();
 			final byte[] base64EncodedByteAr = Base64.encodeBase64(encoded);
 			return new String(base64EncodedByteAr);

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/DefaultESPasswordHashGenerator.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/DefaultESPasswordHashGenerator.java
@@ -11,8 +11,9 @@
  ******************************************************************************/
 package org.eclipse.emf.emfstore.internal.server.accesscontrol;
 
+import java.security.SecureRandom;
+
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.emf.emfstore.server.auth.ESPasswordHashGenerator;
 
 /**
@@ -25,9 +26,21 @@ import org.eclipse.emf.emfstore.server.auth.ESPasswordHashGenerator;
 public class DefaultESPasswordHashGenerator implements ESPasswordHashGenerator {
 
 	/**
+	 * {@link SecureRandom} instance used by the generator.
+	 */
+	protected static final SecureRandom SECURERANDOM = new SecureRandom();
+
+	/**
 	 * Default length of the generated salt.
 	 */
 	protected static final int SALT_PREFIX_LENGTH = 128;
+
+	/** Alphanumeric characters. */
+	protected static final String ALPHANUMERIC = "1234567890" + //$NON-NLS-1$
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ" + //$NON-NLS-1$
+		"abcdefghijklmnopqrstuvwxyz"; //$NON-NLS-1$
+
+	private static final char[] ALPHANUMERIC_CHARS = ALPHANUMERIC.toCharArray();
 
 	/**
 	 * {@inheritDoc}
@@ -43,8 +56,20 @@ public class DefaultESPasswordHashGenerator implements ESPasswordHashGenerator {
 	/**
 	 * @return the generated salt
 	 */
-	protected String generateSalt() {
-		return RandomStringUtils.randomAlphanumeric(SALT_PREFIX_LENGTH);
+	public String generateSalt() {
+		return generateSalt(SALT_PREFIX_LENGTH);
+	}
+
+	/**
+	 * @param length the length of the generated salt
+	 * @return the generated salt
+	 */
+	public String generateSalt(int length) {
+		final char[] randomChars = new char[length];
+		for (int i = 0; i < length; i++) {
+			randomChars[i] = ALPHANUMERIC_CHARS[SECURERANDOM.nextInt(ALPHANUMERIC_CHARS.length)];
+		}
+		return new String(randomChars);
 	}
 
 	private String createHash(String password, final String salt) {

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/authentication/verifiers/PasswordVerifier.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/authentication/verifiers/PasswordVerifier.java
@@ -80,7 +80,7 @@ public abstract class PasswordVerifier implements ESUserVerifier {
 	protected boolean verifySuperUser(String username, String password) {
 		final ESPasswordHashGenerator passwordHashGenerator = AccessControl.getESPasswordHashGenerator();
 		if (hash == null && salt == null) {
-			return username.equals(superuser) && ServerConfiguration.SUPER_USER_PASSWORD_DEFAULT.equals(password);
+			return false;
 		}
 		return username.equals(superuser) && passwordHashGenerator.verifyPassword(password, hash, salt);
 	}

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/authentication/verifiers/PasswordVerifier.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/accesscontrol/authentication/verifiers/PasswordVerifier.java
@@ -79,7 +79,7 @@ public abstract class PasswordVerifier implements ESUserVerifier {
 	 */
 	protected boolean verifySuperUser(String username, String password) {
 		final ESPasswordHashGenerator passwordHashGenerator = AccessControl.getESPasswordHashGenerator();
-		if (hash == null && salt == null) {
+		if (hash == null || salt == null) {
 			return false;
 		}
 		return username.equals(superuser) && passwordHashGenerator.verifyPassword(password, hash, salt);

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
@@ -157,7 +157,7 @@ emfstore.accesscontrol.authentication.superuser = super
 # Options: Any password
 # Default: "super"
 #
-emfstore.accesscontrol.authentication.superuser.password = super
+# emfstore.accesscontrol.authentication.superuser.password = super
 
 # Defines the session timeout for a user session. If a session is inactive for this period of time, 
 # the session will be destroyed.

--- a/tests/org.eclipse.emf.emfstore.client.test/src/org/eclipse/emf/emfstore/internal/client/test/config/ServerLocationProvider.java
+++ b/tests/org.eclipse.emf.emfstore.client.test/src/org/eclipse/emf/emfstore/internal/client/test/config/ServerLocationProvider.java
@@ -23,6 +23,10 @@ public class ServerLocationProvider extends DefaultServerWorkspaceLocationProvid
 	 */
 	@Override
 	protected String getRootDirectory() {
+		final String rootDir = System.getenv("EMFSTORE_TEST_SERVER_ROOT_DIR");
+		if (rootDir != null && rootDir.length() > 0) {
+			return rootDir;
+		}
 		return ResourcesPlugin.getWorkspace().getRoot().getLocation().toString();
 	}
 }

--- a/tests/org.eclipse.emf.emfstore.server.test/AllServerTests.launch
+++ b/tests/org.eclipse.emf.emfstore.server.test/AllServerTests.launch
@@ -12,6 +12,7 @@
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
 <booleanAttribute key="default" value="false"/>
+<setAttribute key="deselected_workspace_bundles"/>
 <booleanAttribute key="includeOptional" value="false"/>
 <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
@@ -33,8 +34,62 @@
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>
 <booleanAttribute key="run_in_ui_thread" value="false"/>
-<stringAttribute key="selected_target_plugins" value="com.google.guava@default:default,com.ibm.icu@default:default,javax.annotation@default:default,javax.inject@default:default,org.apache.batik.css*1.7.0.v201011041433@default:default,org.apache.batik.css*1.8.0.v20170214-1941@default:default,org.apache.batik.util*1.7.0.v201011041433@default:default,org.apache.batik.util*1.8.0.v20170214-1941@default:default,org.apache.batik.util.gui*1.7.0.v200903091627@default:default,org.apache.batik.util.gui*1.8.0.v20170214-1941@default:default,org.apache.commons.codec@default:default,org.apache.commons.jxpath@default:default,org.apache.commons.logging@default:default,org.apache.felix.scr@1:true,org.eclipse.ant.core@default:default,org.eclipse.compare.core@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.linux.x86_64@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.e4.core.commands@default:default,org.eclipse.e4.core.contexts@default:default,org.eclipse.e4.core.di.annotations@default:default,org.eclipse.e4.core.di.extensions.supplier@default:default,org.eclipse.e4.core.di.extensions@default:default,org.eclipse.e4.core.di@default:default,org.eclipse.e4.core.services@default:default,org.eclipse.e4.emf.xpath@default:default,org.eclipse.e4.ui.bindings@default:default,org.eclipse.e4.ui.css.core@default:default,org.eclipse.e4.ui.css.swt.theme@default:default,org.eclipse.e4.ui.css.swt@default:default,org.eclipse.e4.ui.di@default:default,org.eclipse.e4.ui.model.workbench@default:default,org.eclipse.e4.ui.services@default:default,org.eclipse.e4.ui.swt.gtk@default:false,org.eclipse.e4.ui.widgets@default:default,org.eclipse.e4.ui.workbench.addons.swt@default:default,org.eclipse.e4.ui.workbench.renderers.swt@default:default,org.eclipse.e4.ui.workbench.swt@default:default,org.eclipse.e4.ui.workbench3@default:default,org.eclipse.e4.ui.workbench@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.emf.edit@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.region@default:false,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.help@default:default,org.eclipse.jface.databinding@default:default,org.eclipse.jface@default:default,org.eclipse.osgi*3.12.100.v20180210-1608@-1:true,org.eclipse.osgi.compatibility.state@default:false,org.eclipse.osgi.services*3.6.0.v20170228-1906@default:default,org.eclipse.osgi.util*3.4.0.v20170111-1608@default:default,org.eclipse.swt.gtk.linux.x86_64@default:false,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.ui.trace@default:default,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:default,org.hamcrest.core*1.3.0.v201303031735@default:default,org.hamcrest.core*1.3.0.v20180420-1519@default:default,org.hamcrest.library@default:default,org.junit@default:default,org.w3c.css.sac@default:default,org.w3c.dom.events@default:default,org.w3c.dom.smil*1.0.1.v200903091627@default:default,org.w3c.dom.svg@default:default"/>
-<stringAttribute key="selected_workspace_plugins" value="org.eclipse.emf.emfstore.client.api.test@default:false,org.eclipse.emf.emfstore.client.changetracking.test@default:false,org.eclipse.emf.emfstore.client.conflictdetection.test@default:false,org.eclipse.emf.emfstore.client.recording.test@default:false,org.eclipse.emf.emfstore.client@default:default,org.eclipse.emf.emfstore.common.model@default:default,org.eclipse.emf.emfstore.common@default:default,org.eclipse.emf.emfstore.examplemodel@default:default,org.eclipse.emf.emfstore.migration@default:default,org.eclipse.emf.emfstore.modelmutator@default:default,org.eclipse.emf.emfstore.server.model@default:default,org.eclipse.emf.emfstore.server.test@default:false,org.eclipse.emf.emfstore.server@default:default,org.eclipse.emf.emfstore.test.common@default:default,org.eclipse.emf.emfstore.test.model.edit@default:default,org.eclipse.emf.emfstore.test.model@default:default"/>
+<setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:default"/>
+<setEntry value="com.google.guava@default:default"/>
+<setEntry value="javax.xml@default:default"/>
+<setEntry value="org.apache.commons.codec*1.6.0.v201305230611@default:default"/>
+<setEntry value="org.apache.felix.gogo.command@default:default"/>
+<setEntry value="org.apache.felix.gogo.runtime@default:default"/>
+<setEntry value="org.eclipse.ant.core@default:default"/>
+<setEntry value="org.eclipse.core.contenttype@default:default"/>
+<setEntry value="org.eclipse.core.expressions@default:default"/>
+<setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
+<setEntry value="org.eclipse.core.filesystem@default:default"/>
+<setEntry value="org.eclipse.core.jobs@default:default"/>
+<setEntry value="org.eclipse.core.resources@default:default"/>
+<setEntry value="org.eclipse.core.runtime.compatibility.registry@default:default"/>
+<setEntry value="org.eclipse.core.runtime@default:true"/>
+<setEntry value="org.eclipse.core.variables@default:default"/>
+<setEntry value="org.eclipse.emf.cdo.ecore.retrofit@default:default"/>
+<setEntry value="org.eclipse.emf.common@default:default"/>
+<setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
+<setEntry value="org.eclipse.emf.ecore@default:default"/>
+<setEntry value="org.eclipse.emf.edit@default:default"/>
+<setEntry value="org.eclipse.equinox.app@default:default"/>
+<setEntry value="org.eclipse.equinox.common@2:true"/>
+<setEntry value="org.eclipse.equinox.ds@1:true"/>
+<setEntry value="org.eclipse.equinox.preferences@default:default"/>
+<setEntry value="org.eclipse.equinox.registry@default:default"/>
+<setEntry value="org.eclipse.equinox.servletbridge.extensionbundle@default:default"/>
+<setEntry value="org.eclipse.equinox.transforms.hook@default:false"/>
+<setEntry value="org.eclipse.equinox.util@default:default"/>
+<setEntry value="org.eclipse.equinox.weaving.hook@default:false"/>
+<setEntry value="org.eclipse.osgi*3.8.2.v20130124-134944@-1:true"/>
+<setEntry value="org.eclipse.osgi.services@default:default"/>
+<setEntry value="org.eclipse.team.core@default:default"/>
+<setEntry value="org.hamcrest.core*1.3.0.v201303031735@default:default"/>
+<setEntry value="org.hamcrest.library@default:default"/>
+<setEntry value="org.junit*4.10.0.v4_10_0_v20120426-0900@default:default"/>
+<setEntry value="org.slf4j.api@default:default"/>
+<setEntry value="org.slf4j.jcl@default:default"/>
+</setAttribute>
+<setAttribute key="selected_workspace_bundles">
+<setEntry value="org.eclipse.emf.emfstore.client@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.common@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.examplemodel@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.migration@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.modelmutator@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.model@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.server.test@default:false"/>
+<setEntry value="org.eclipse.emf.emfstore.server@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.test.common@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.test.model.edit@default:default"/>
+<setEntry value="org.eclipse.emf.emfstore.test.model@default:default"/>
+</setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <booleanAttribute key="tracing" value="false"/>
 <booleanAttribute key="useCustomFeatures" value="false"/>

--- a/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
+++ b/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
@@ -11,11 +11,11 @@
  ******************************************************************************/
 package org.eclipse.emf.emfstore.server.accesscontrol.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.emfstore.internal.server.accesscontrol.DefaultESPasswordHashGenerator;
-import org.eclipse.emf.emfstore.server.auth.ESPasswordHashGenerator;
 import org.eclipse.emf.emfstore.server.auth.ESPasswordHashGenerator.ESHashAndSalt;
 import org.junit.Test;
 
@@ -28,7 +28,7 @@ public class DefaultESPasswordHashGeneratorTests {
 	private static final String TEST_SALT = "nPkctDB1Q45EOv6lyn5DiG14vEzAUeYhNbtKOWutolQayr2idOctVc2xpo6q4p6oUmYU1cG1q2DzQgJ0zHKctIP1SrKzEJzdAqYesRhoXLTLvGbuElGNaYBbd3eb8cRZ"; //$NON-NLS-1$
 
 	/* stateless */
-	private final ESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator();
+	private final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator();
 
 	@Test
 	public void testHashPasswordSamePasswordDifferentSalts() {
@@ -53,6 +53,18 @@ public class DefaultESPasswordHashGeneratorTests {
 		assertFalse(passwordHashGenerator.verifyPassword(null, TEST_HASH, TEST_SALT));
 		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, null, TEST_SALT));
 		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, TEST_HASH, null));
+	}
+
+	@Test
+	public void testGenerateSalt() {
+		final String salt = passwordHashGenerator.generateSalt();
+		assertEquals(128, salt.length());
+	}
+
+	@Test
+	public void testGenerateSaltWthCustomLength() {
+		final String salt = passwordHashGenerator.generateSalt(100);
+		assertEquals(100, salt.length());
 	}
 
 }

--- a/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
+++ b/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
@@ -12,7 +12,6 @@
 package org.eclipse.emf.emfstore.server.accesscontrol.test;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.emfstore.internal.server.accesscontrol.DefaultESPasswordHashGenerator;
@@ -35,8 +34,8 @@ public class DefaultESPasswordHashGeneratorTests {
 	public void testHashPasswordSamePasswordDifferentSalts() {
 		final ESHashAndSalt hash1 = passwordHashGenerator.hashPassword(PASSWORD);
 		final ESHashAndSalt hash2 = passwordHashGenerator.hashPassword(PASSWORD);
-		assertNotEquals(hash1.getSalt(), hash2.getSalt());
-		assertNotEquals(hash1.getHash(), hash2.getHash());
+		assertFalse(hash1.getSalt().equals(hash2.getSalt()));
+		assertFalse(hash1.getHash().equals(hash2.getHash()));
 	}
 
 	@Test

--- a/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
+++ b/tests/org.eclipse.emf.emfstore.server.test/src/org/eclipse/emf/emfstore/server/accesscontrol/test/DefaultESPasswordHashGeneratorTests.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.security.NoSuchAlgorithmException;
+
 import org.eclipse.emf.emfstore.internal.server.accesscontrol.DefaultESPasswordHashGenerator;
 import org.eclipse.emf.emfstore.server.auth.ESPasswordHashGenerator.ESHashAndSalt;
 import org.junit.Test;
@@ -24,14 +26,13 @@ public class DefaultESPasswordHashGeneratorTests {
 	private static final String PASSWORD = "IAmPassword"; //$NON-NLS-1$
 	private static final String NOT_PASSWORD = "IAmNotPassword"; //$NON-NLS-1$
 
-	private static final String TEST_HASH = "eaf6acf17676f0b6bd554af88350c905fd0a444ec962f1840e7fabf182c79e881c3589ff66667b1f56e73a84b6585b57ef3d82e914b3584be18d3ad6e9641a9f"; //$NON-NLS-1$
+	private static final String TEST_HASH_LEGACY = "eaf6acf17676f0b6bd554af88350c905fd0a444ec962f1840e7fabf182c79e881c3589ff66667b1f56e73a84b6585b57ef3d82e914b3584be18d3ad6e9641a9f"; //$NON-NLS-1$
+	private static final String TEST_HASH = "karb/oZpKWiDa6VUDe2ERQ=="; //$NON-NLS-1$
 	private static final String TEST_SALT = "nPkctDB1Q45EOv6lyn5DiG14vEzAUeYhNbtKOWutolQayr2idOctVc2xpo6q4p6oUmYU1cG1q2DzQgJ0zHKctIP1SrKzEJzdAqYesRhoXLTLvGbuElGNaYBbd3eb8cRZ"; //$NON-NLS-1$
 
-	/* stateless */
-	private final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator();
-
 	@Test
-	public void testHashPasswordSamePasswordDifferentSalts() {
+	public void testHashPasswordSamePasswordDifferentSalts() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(false);
 		final ESHashAndSalt hash1 = passwordHashGenerator.hashPassword(PASSWORD);
 		final ESHashAndSalt hash2 = passwordHashGenerator.hashPassword(PASSWORD);
 		assertFalse(hash1.getSalt().equals(hash2.getSalt()));
@@ -39,30 +40,64 @@ public class DefaultESPasswordHashGeneratorTests {
 	}
 
 	@Test
-	public void testVerifyPasswordMatching() {
+	public void testVerifyPasswordMatching() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(false);
 		assertTrue(passwordHashGenerator.verifyPassword(PASSWORD, TEST_HASH, TEST_SALT));
 	}
 
 	@Test
-	public void testVerifyPasswordNotMatching() {
+	public void testVerifyPasswordNotMatching() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(false);
 		assertFalse(passwordHashGenerator.verifyPassword(NOT_PASSWORD, TEST_HASH, TEST_SALT));
 	}
 
 	@Test
-	public void testVerifyPasswordInvalidInput() {
+	public void testVerifyPasswordInvalidInput() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(false);
 		assertFalse(passwordHashGenerator.verifyPassword(null, TEST_HASH, TEST_SALT));
 		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, null, TEST_SALT));
 		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, TEST_HASH, null));
 	}
 
 	@Test
-	public void testGenerateSalt() {
+	public void testHashPasswordSamePasswordDifferentSaltsLegacy() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(true);
+		final ESHashAndSalt hash1 = passwordHashGenerator.hashPassword(PASSWORD);
+		final ESHashAndSalt hash2 = passwordHashGenerator.hashPassword(PASSWORD);
+		assertFalse(hash1.getSalt().equals(hash2.getSalt()));
+		assertFalse(hash1.getHash().equals(hash2.getHash()));
+	}
+
+	@Test
+	public void testVerifyPasswordMatchingLegacy() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(true);
+		assertTrue(passwordHashGenerator.verifyPassword(PASSWORD, TEST_HASH_LEGACY, TEST_SALT));
+	}
+
+	@Test
+	public void testVerifyPasswordNotMatchingLegacy() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(true);
+		assertFalse(passwordHashGenerator.verifyPassword(NOT_PASSWORD, TEST_HASH_LEGACY, TEST_SALT));
+	}
+
+	@Test
+	public void testVerifyPasswordInvalidInputLegacy() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator(true);
+		assertFalse(passwordHashGenerator.verifyPassword(null, TEST_HASH_LEGACY, TEST_SALT));
+		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, null, TEST_SALT));
+		assertFalse(passwordHashGenerator.verifyPassword(PASSWORD, TEST_HASH_LEGACY, null));
+	}
+
+	@Test
+	public void testGenerateSalt() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator();
 		final String salt = passwordHashGenerator.generateSalt();
 		assertEquals(128, salt.length());
 	}
 
 	@Test
-	public void testGenerateSaltWthCustomLength() {
+	public void testGenerateSaltWthCustomLength() throws NoSuchAlgorithmException {
+		final DefaultESPasswordHashGenerator passwordHashGenerator = new DefaultESPasswordHashGenerator();
 		final String salt = passwordHashGenerator.generateSalt(100);
 		assertEquals(100, salt.length());
 	}

--- a/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/config/ServerLocationProvider.java
+++ b/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/config/ServerLocationProvider.java
@@ -23,6 +23,10 @@ public class ServerLocationProvider extends DefaultServerWorkspaceLocationProvid
 	 */
 	@Override
 	protected String getRootDirectory() {
+		final String rootDir = System.getenv("EMFSTORE_TEST_SERVER_ROOT_DIR"); //$NON-NLS-1$
+		if (rootDir != null && rootDir.length() > 0) {
+			return rootDir;
+		}
 		return ResourcesPlugin.getWorkspace().getRoot().getLocation().toString();
 	}
 }

--- a/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/util/ServerUtil.java
+++ b/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/util/ServerUtil.java
@@ -74,8 +74,6 @@ import org.osgi.framework.FrameworkUtil;
  */
 public final class ServerUtil {
 
-	private static final String EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT = "emfstore.accesscontrol.authentication.superuser.password.salt"; //$NON-NLS-1$
-	private static final String EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH = "emfstore.accesscontrol.authentication.superuser.password.hash"; //$NON-NLS-1$
 	private static final String ES_PROPERTIES_FILE = "es.properties"; //$NON-NLS-1$
 
 	private ServerUtil() {
@@ -165,12 +163,12 @@ public final class ServerUtil {
 
 		// make sure that if no super user password is set, we set the default one
 		final Map<String, String> additionalProperties = new LinkedHashMap<String, String>(properties);
-		if (!properties.containsKey(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH) &&
-			!properties.containsKey(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT) &&
+		if (!properties.containsKey(ServerConfiguration.SUPER_USER_PASSWORD_HASH) &&
+			!properties.containsKey(ServerConfiguration.SUPER_USER_PASSWORD_SALT) &&
 			!properties.containsKey(ServerConfiguration.SUPER_USER_PASSWORD)) {
-			additionalProperties.put(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH,
+			additionalProperties.put(ServerConfiguration.SUPER_USER_PASSWORD_HASH,
 				"f262c3daf9b9c8fd380bdf34a415ee01c38e423d956d4f9c732273cf51264783787415c3b6d8701f3416735a31b06b8330e0be0d17ae5361ef83de320f17ba84"); //$NON-NLS-1$
-			additionalProperties.put(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT,
+			additionalProperties.put(ServerConfiguration.SUPER_USER_PASSWORD_SALT,
 				"8a0InZ2yZMss65zHJrdhOXU6CqF8EeFncdv7V29ZO4qD565i5deWWXIi7aRkYwbY2BWamdOYQGqoZeZiJHZ0BH1mteMIhu3eIG5D2twfVQtjetvf8kiLOMwnYDsk4HPq"); //$NON-NLS-1$
 		}
 

--- a/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/util/ServerUtil.java
+++ b/tests/org.eclipse.emf.emfstore.test.common/src/org/eclipse/emf/emfstore/client/test/common/util/ServerUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -73,6 +74,8 @@ import org.osgi.framework.FrameworkUtil;
  */
 public final class ServerUtil {
 
+	private static final String EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT = "emfstore.accesscontrol.authentication.superuser.password.salt"; //$NON-NLS-1$
+	private static final String EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH = "emfstore.accesscontrol.authentication.superuser.password.hash"; //$NON-NLS-1$
 	private static final String ES_PROPERTIES_FILE = "es.properties"; //$NON-NLS-1$
 
 	private ServerUtil() {
@@ -160,7 +163,18 @@ public final class ServerUtil {
 		copyFileToWorkspace(ServerConfiguration.getServerKeyStorePath(), ServerConfiguration.SERVER_KEYSTORE_FILE,
 			Messages.ServerUtil_Failed_To_Copy_Keystore, Messages.ServerUtil_Keystore_Copied_To_Server_Workspace);
 
-		ServerConfiguration.setProperties(initProperties(properties));
+		// make sure that if no super user password is set, we set the default one
+		final Map<String, String> additionalProperties = new LinkedHashMap<String, String>(properties);
+		if (!properties.containsKey(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH) &&
+			!properties.containsKey(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT) &&
+			!properties.containsKey(ServerConfiguration.SUPER_USER_PASSWORD)) {
+			additionalProperties.put(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_HASH,
+				"f262c3daf9b9c8fd380bdf34a415ee01c38e423d956d4f9c732273cf51264783787415c3b6d8701f3416735a31b06b8330e0be0d17ae5361ef83de320f17ba84"); //$NON-NLS-1$
+			additionalProperties.put(EMFSTORE_ACCESSCONTROL_AUTHENTICATION_SUPERUSER_PASSWORD_SALT,
+				"8a0InZ2yZMss65zHJrdhOXU6CqF8EeFncdv7V29ZO4qD565i5deWWXIi7aRkYwbY2BWamdOYQGqoZeZiJHZ0BH1mteMIhu3eIG5D2twfVQtjetvf8kiLOMwnYDsk4HPq"); //$NON-NLS-1$
+		}
+
+		ServerConfiguration.setProperties(initProperties(additionalProperties));
 		setSuperUser(daoFacadeMock);
 		final AccessControl accessControl = new AccessControl(
 			ESAuthenticationControlType.model,


### PR DESCRIPTION
* Remove default super user password and fix test configuration / test util classes
* use SecureRandom for salt generation
* allow to use a different hash function to hash passwords. Old approach kept as default to keep backward compatibility. 

Verification Build: https://ci.eclipse.org/emfstore/job/PRs/view/change-requests/job/PR-4/