### PR TITLE
Add logging for project branch initialization

### DIFF
--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
@@ -275,6 +275,16 @@ public final class ServerConfiguration {
 	public static final String LOAD_STARTUP_LISTENER_DEFAULT = Boolean.TRUE.toString();
 
 	/**
+	 * Whether the server should exit if there is an error while initializing missing project branches.
+	 */
+	public static final String STARTUP_EXIT_ON_BRANCH_INIT_ERROR = "emfstore.startup.branch.init.exit.on.fail"; //$NON-NLS-1$
+
+	/**
+	 * Default values for {@link #STARTUP_EXIT_ON_BRANCH_INIT_ERROR}.
+	 */
+	public static final String STARTUP_EXIT_ON_BRANCH_INIT_ERROR_DEFAULT = Boolean.TRUE.toString();
+
+	/**
 	 * Property name of accepted client versions. Enter the version's names or
 	 * any, seperate multiple entries with {@link #MULTI_PROPERTY_SEPERATOR}.
 	 */

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
@@ -228,6 +228,13 @@ emfstore.accesscontrol.authentication.ldap.2.base=ou=Personen,ou=IN,o=TUM,c=DE
 emfstore.accesscontrol.authentication.ldap.2.searchdn=uid
 
 
+# Configures the EMFStore controller.
+# Defines whether the EMFStore should exit if initialization of missing branches fails for any project.
+# Options: true or false
+# Default: true
+#
+emfstore.startup.branch.init.exit.on.fail = true
+
 #
 # Plugin configuration.
 #

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/startup/ServerHrefMigrator.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/startup/ServerHrefMigrator.java
@@ -169,6 +169,7 @@ public class ServerHrefMigrator {
 	}
 
 	private List<String> doMigrate(String serverHome) throws InvocationTargetException {
+		ModelUtil.logInfo("[ServerHrefMigrator] Execute migration for server home: " + serverHome); //$NON-NLS-1$
 		migrateNonContainment(serverHome + STORAGE_USS, "projects", new ServerSpaceRule()); //$NON-NLS-1$
 
 		final File serverHomeFile = new File(serverHome);


### PR DESCRIPTION
- Add logging to the EMFStoreController to be able to track down projects failing branch initialization
- Allow to configure that the server continues to run when branch initialization fails
- Log when the ServerHrefMigrator migrates a server space